### PR TITLE
Update Authorization Request to accept any content-type

### DIFF
--- a/lib/src/channels/endpoint_authorizable_channel/http_token_authorization_delegate.dart
+++ b/lib/src/channels/endpoint_authorizable_channel/http_token_authorization_delegate.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
+
+import 'package:dart_pusher_channels/src/channels/endpoint_authorizable_channel/endpoint_authorization_delegate.dart';
 import 'package:dart_pusher_channels/src/channels/presence_channel.dart';
 import 'package:dart_pusher_channels/src/channels/private_channel.dart';
 import 'package:dart_pusher_channels/src/channels/private_encrypted_channel.dart';
 import 'package:dart_pusher_channels/src/exception/exception.dart';
 import 'package:http/http.dart' as http;
-import 'package:dart_pusher_channels/src/channels/endpoint_authorizable_channel/endpoint_authorization_delegate.dart';
 import 'package:meta/meta.dart';
 
 typedef EndpointAuthorizableChannelTokenAuthorizationParser<
@@ -97,6 +98,8 @@ class EndpointAuthorizableChannelTokenAuthorizationDelegate<
   ///   ...headers,
   ///   'content-type': 'application/x-www-form-urlencoded'
   /// },
+  ///
+  /// EXAMPLE: IF YOUR ENDPOINT ACCEPT ONLY application/json, YOU SHOULD SET THE CONTENT-TYPE HEADER TO application/json
   /// ...
   /// ```
   ///
@@ -110,12 +113,13 @@ class EndpointAuthorizableChannelTokenAuthorizationDelegate<
   ///
   @override
   Future<T> authorizationData(String socketId, String channelName) async {
+    if (!headers.containsKey('content-type')) {
+      headers['content-type'] = 'application/x-www-form-urlencoded';
+    }
+
     final response = await http.post(
       authorizationEndpoint,
-      headers: {
-        ...headers,
-        'content-type': 'application/x-www-form-urlencoded'
-      },
+      headers: headers,
       body: {
         'socket_id': socketId,
         'channel_name': channelName,


### PR DESCRIPTION
My authorization endpoint only accept'Application/Json', 

I was consistently receiving an error when trying to authorize a private channel, even after adding the following headers:
```
client.privateChannel(
'App.Models.User.6',
authorizationDelegate: EndpointAuthorizableChannelTokenAuthorizationDelegate.forPrivateChannel(
        .........
	headers: {
	'Accept':  'application/json',
	......
	},
),
);
```
Upon closer inspection and thorough network debugging, I discovered that the **content-type** was being **overwritten** later in the code:

http_token_authorization_delegate.dart:
```
Future<T> authorizationData(String  socketId, String  channelName) async {
....
headers: {
  ...headers,
  'content-type': 'application/x-www-form-urlencoded'
},..
```

Your consideration in accepting this pull request is highly appreciated. I have found this package to be incredibly helpful, and I'm excited to contribute to its improvement. Please review and merge at your earliest convenience.

Keep coding! 👋