### PR TITLE
expose socket id

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -175,6 +175,9 @@ class PusherChannelsClient {
       )
       .map(voidStreamMapper);
 
+  /// Used to get the socket id of the client
+  String? get socketId => controller.socketId;
+
   bool get isDisposed => _isDisposed;
 
   @visibleForTesting


### PR DESCRIPTION
Exposing socket id through the client is useful when the user needs to get the socket id for reasons such as manually attaching x-socket-id header to requests via their networking package etc, dio, http...